### PR TITLE
Fix BTT SKR E3 Mini v1.2 baud rate

### DIFF
--- a/Marlin/board_def.h
+++ b/Marlin/board_def.h
@@ -16,7 +16,7 @@
 #define motherboard_name BOARD_BTT_SKR_MINI_E3_V1_2
 #define SERIAL_PORT 2
 #define SERIAL_PORT_2 -1
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 #endif
 
 #if ENABLED(BTTSKR1_3)


### PR DESCRIPTION
Fix BTT SKR E3 Mini v1.2 baud rate

BTT uses 115200 baud rate for this board:
https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/blob/master/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/Configuration.h#L124

The wrong baud rate was causing my TFT35 E3 v.3.0 to not work in touch mode. This fixes that (and maybe some other issues)