### PR TITLE
Fix wrong variable naming

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -115,7 +115,7 @@ Board name: FYSETCV1_1A, FYSETCV1_1B, FYSETCV1_2A, FYSETCV1_2B, change_value = S
 #define x_driver_type TMC2209  //For Debugging purposes only. Please ignore this line of code
 #define y_driver_type TMC2209  //For Debugging purposes only. Please ignore this line of code
 #define z_driver_type TMC2209  //For Debugging purposes only. Please ignore this line of code
-#define e_driver_type TMC2209 //For Debugging purposes only. Please ignore this line of code
+#define e0_driver_type TMC2209 //For Debugging purposes only. Please ignore this line of code
 #else
 
 /*** *** *** Section 2 - Choose your driver types here. You can also add additional drivers per axis if you like*** *** ***/

--- a/Marlin/sensorprob_off.h
+++ b/Marlin/sensorprob_off.h
@@ -45,7 +45,7 @@
 
    #if ENABLED(FIX_MOUNTED_PROBE) //variable
 
-   #if ENABLE (KAY3DCoreXY_KAVA_E3)
+   #if ENABLED(KAY3DCoreXY_KAVA_E3)
       #define NOZZLE_TO_PROBE_OFFSET { -42, -12, 0 }
       #endif 
 


### PR DESCRIPTION
Fix wrong variable naming in debug mode
`e_driver_type` --> `e0_driver_type`

This will also fix #2 